### PR TITLE
LS-118: Implementing a shared module to export common modules.

### DIFF
--- a/src/app/biometrics/biometrics.module.ts
+++ b/src/app/biometrics/biometrics.module.ts
@@ -1,26 +1,20 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 
 // Components
 import { BiometricsComponent } from './components/biometrics';
 // Modules
-import { MatFormFieldModule, MatInputModule, MatSelectModule } from '@angular/material';
 import { BiometricsRoutesModule } from './biometrics.routes';
 // Services
 import { BiometricsService } from './biometrics.service';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [
     BiometricsComponent
   ],
   imports: [
-    CommonModule,
-    FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    BiometricsRoutesModule
+    BiometricsRoutesModule,
+    SharedModule
   ],
   providers: [
     BiometricsService

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule, MatInputModule, MatSelectModule } from '@angular/material';
+
+@NgModule({
+  imports: [
+  ],
+  exports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule
+  ],
+  declarations: []
+})
+export class SharedModule { }


### PR DESCRIPTION
Pretty simple change - just refactoring out common stuff to a shared area. We can add to it over time.

Just include the shared module in any module that you create. Current example is biometrics module. 
```
# biometrics.module.ts
imports: [
  SharedModule
],
```