### PR TITLE
LS-119: Adding firebase rules.

### DIFF
--- a/firebase.rules.json
+++ b/firebase.rules.json
@@ -7,4 +7,8 @@
       }
     }
   }
+  // "rules": {
+  //   ".read": "auth != null",
+  //   ".write": "auth != null"
+  // }
 }

--- a/firebase.rules.json
+++ b/firebase.rules.json
@@ -1,3 +1,10 @@
 {
-  "rules": {}
+  "rules": {
+    "biometrics": {
+      "$uid": {
+        ".read": "$uid === auth.uid",
+        ".write": "$uid === auth.uid"
+      }
+    }
+  }
 }

--- a/src/app/auth/guards/require-auth.guard.ts
+++ b/src/app/auth/guards/require-auth.guard.ts
@@ -1,6 +1,3 @@
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/take';
-
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';


### PR DESCRIPTION
1) Adding firebase rules used by the CLI. This is the firebase.rules.json. 
2) Updated the firebase rules at the hosted app level: https://console.firebase.google.com/project/leafapp-e61f4/database/leafapp-e61f4/rules

The second is what actually drivers the security. The biometrics route guard only requires the user to be logged in, but to access the data, the firebase rules are in place to ensure each has access to only their biometric data.

The commented out rules section is a way to allow any authenticated user complete read/write access to the entire database. If we need to bypass rules temporarily while working on a dev task, that's how you would do it.